### PR TITLE
Use fstr with mkfstr

### DIFF
--- a/ncwb.c
+++ b/ncwb.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
 			strcpy(fstr, mkfstr(str, estr, str , &len));
 
 		} else {
-			strcpy(str, mkfstr(str, estr, argv[0], &len));
+			strcpy(fstr, mkfstr(str, estr, argv[0], &len));
 			str++;
 		}
 		lns = cchar(str, '\n');


### PR DESCRIPTION
On macOS 10.13.6, this line was trowing an `Abort trap: 6`
error, caused by the string being copied into `str` being 
far longer than `str`. Switching to `fstr` for `figlet`
strings makes the program work with `figlet`.